### PR TITLE
Enhance iOS push notification support and FCM init

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -63,20 +63,20 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 
-	<!-- İnternet izinleri için App Transport Security -->
+	<!-- İnternet izinleri -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 
-	<!-- Dosya paylaşımı ve erişim izinleri -->
+	<!-- Dosya paylaşımı -->
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 
-	<!-- Deep link / URL scheme -->
+	<!-- Deep Link / URL Scheme -->
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -90,8 +90,20 @@
 		</dict>
 	</array>
 
-	<!-- Flutter embedded views preview -->
+	<!-- Flutter embedded views -->
 	<key>io.flutter.embedded_views_preview</key>
+	<true/>
+
+	<!-- 🔔 Firebase Push Notification için eklendi -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+
+	<key>NSUserNotificationAlertStyle</key>
+	<string>alert</string>
+
+	<key>FirebaseAppDelegateProxyEnabled</key>
 	<true/>
 </dict>
 </plist>

--- a/lib/data/services/notification_service.dart
+++ b/lib/data/services/notification_service.dart
@@ -6,15 +6,36 @@ class NotificationService {
   static Future<void> initFCMToken() async {
     final FirebaseMessaging messaging = FirebaseMessaging.instance;
 
-    NotificationSettings settings = await messaging.requestPermission();
+    // 1️⃣ Kullanıcıdan izin iste
+    NotificationSettings settings = await messaging.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
 
+    // 2️⃣ İzin verildiyse devam et
     if (settings.authorizationStatus == AuthorizationStatus.authorized) {
-      String? token = await messaging.getToken();
+      // 3️⃣ APNs token hazır mı kontrol et (iOS için)
+      String? apnsToken;
+      try {
+        apnsToken = await messaging.getAPNSToken();
+      } catch (e) {
+        print("APNS token alınamadı: $e");
+      }
 
-      if (token != null) {
-        final localDataSource = sl<LocalDataSource>();
-        await localDataSource.setDeviceToken(token);
-        print('Token kaydedildi: $token');
+      if (apnsToken != null) {
+        // 4️⃣ FCM token al
+        String? token = await messaging.getToken();
+
+        if (token != null) {
+          final localDataSource = sl<LocalDataSource>();
+          await localDataSource.setDeviceToken(token);
+          print('FCM Token kaydedildi: $token');
+        } else {
+          print("FCM token alınamadı");
+        }
+      } else {
+        print("APNS token henüz hazır değil.");
       }
     } else {
       print('Bildirim izni reddedildi.');


### PR DESCRIPTION
Updated Info.plist to enable background remote notifications, set alert style, and allow Firebase delegate proxy for push notifications. Improved notification_service.dart to explicitly request alert, badge, and sound permissions, check for APNs token readiness on iOS, and handle FCM token registration more robustly.